### PR TITLE
fix: correct search false positives and remove wordLen parameter

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -12,13 +12,13 @@ int main()
 
     printTrieEntries(root);
 
-    if(search(root, "ball", 5)){
+    if(search(root, "ball")){
         printf("ball found :)\n");
     } else {
         printf("ball not found :(\n");
     }
 
-    bool ret = delete(root, "ball", 5);
+    bool ret = delete(root, "ball");
 
     if(ret){
         printf("delete successful\n");
@@ -26,7 +26,7 @@ int main()
         printf("delete not successful\n");
     }
 
-    if(search(root, "ball", 5)){
+    if(search(root, "ball")){
         printf("ball found :)\n");
     } else {
         printf("ball not found :(\n");

--- a/src/trie.c
+++ b/src/trie.c
@@ -52,52 +52,42 @@ bool insert(TrieNode* root, char* word){
  * Search for a word in the Trie
  * @param root the root of the Trie to search in
  * @param word the word to search for
- * @param wordLen the length of the word
  * @return true if the word is found, otherwise false
  */
-bool search(TrieNode* root, char* word, int wordLen){
+bool search(TrieNode* root, char* word){
     if(!root) return false;
     if(!word) return false;
-    if(!wordLen) return false;
 
     TrieNode* curNode = root;
 
-    int letterIndex;
-
-    for(int wordIndex = 0; wordIndex < wordLen; wordIndex++){
-        letterIndex = word[wordIndex] - 'a';
-        if(curNode->children[letterIndex]){
-            curNode = curNode->children[letterIndex];
-        } else break;
+    for(int wordIndex = 0; word[wordIndex] != '\0'; wordIndex++){
+        int letterIndex = word[wordIndex] - 'a';
+        if(!curNode->children[letterIndex]) return false;
+        curNode = curNode->children[letterIndex];
     }
 
-    if(curNode->endOfWord) return true;
-
-    return false;
+    return curNode->endOfWord;
 }
 
 /**
  * Delete a word from the Trie
  * @param root the root of the Trie to delete from
  * @param word the word to delete
- * @param wordLen the length of the word
  * @return true if the word is deleted, otherwise false
  */
-bool delete(TrieNode* root, char* word, int wordLen){
+bool delete(TrieNode* root, char* word){
     TrieNode* curNode = root;
 
-    int letterIndex = 0;
-
-    for(int wordIndex = 0; wordIndex < wordLen; wordIndex++){
-        letterIndex = word[wordIndex] - 'a';
-        if(curNode->children[letterIndex]){
-            curNode = curNode->children[letterIndex];
-        } else break;
+    for(int wordIndex = 0; word[wordIndex] != '\0'; wordIndex++){
+        int letterIndex = word[wordIndex] - 'a';
+        if(!curNode->children[letterIndex]) return false;
+        curNode = curNode->children[letterIndex];
     }
 
-    if(curNode->endOfWord) curNode->endOfWord = false;
+    if(!curNode->endOfWord) return false;
 
-    return !curNode->endOfWord;
+    curNode->endOfWord = false;
+    return true;
 }
 
 /**

--- a/src/trie.h
+++ b/src/trie.h
@@ -34,19 +34,17 @@ bool insert(TrieNode* root, char* word);
  * Search for a word in the Trie
  * @param root the root of the Trie to search in
  * @param word the word to search for
- * @param wordLen the length of the word
  * @return true if the word is found, otherwise false
  */
-bool search(TrieNode* root, char* word, int wordLen);
+bool search(TrieNode* root, char* word);
 
 /**
  * Delete a word from the Trie
  * @param root the root of the Trie to delete from
  * @param word the word to delete
- * @param wordLen the length of the word
  * @return true if the word is deleted, otherwise false
  */
-bool delete(TrieNode* root, char* word, int wordLen);
+bool delete(TrieNode* root, char* word);
 
 /**
  * Free the entire Trie structure


### PR DESCRIPTION
## Summary
- `search` was checking `endOfWord` on whatever node it stopped at, even when the loop exited early because a child was missing — causing false positives for extensions of inserted words (e.g. insert `ball`, search `balling` → returned `true`)
- Fixed by returning `false` immediately when a child node is not found
- Removed the redundant `wordLen` parameter from `search` and `delete`, aligning them with `insert`'s null-terminator iteration
- `delete` now also correctly returns `false` for words not in the trie

## Test plan
- [ ] Compile: `gcc -Wall -Wextra -Werror src/trie.c src/main.c -o main`
- [ ] Run `./main` — confirm `ball found`, `delete successful`, `ball not found`
- [ ] Manually verify: insert `ball`, search `balling` → not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)