### PR TITLE
fix: validate input characters are in [a-z] in all public functions

### DIFF
--- a/src/trie.c
+++ b/src/trie.c
@@ -34,6 +34,8 @@ bool insert(TrieNode* root, char* word){
     TrieNode* curNode = root;
 
     for(int wordIndex = 0; word[wordIndex] != '\0'; wordIndex++){
+        if(word[wordIndex] < 'a' || word[wordIndex] > 'z') return false;
+
         int childIndex = word[wordIndex] - 'a';
 
         if(!curNode->children[childIndex]){
@@ -61,6 +63,7 @@ bool search(TrieNode* root, char* word){
     TrieNode* curNode = root;
 
     for(int wordIndex = 0; word[wordIndex] != '\0'; wordIndex++){
+        if(word[wordIndex] < 'a' || word[wordIndex] > 'z') return false;
         int letterIndex = word[wordIndex] - 'a';
         if(!curNode->children[letterIndex]) return false;
         curNode = curNode->children[letterIndex];
@@ -79,6 +82,7 @@ bool delete(TrieNode* root, char* word){
     TrieNode* curNode = root;
 
     for(int wordIndex = 0; word[wordIndex] != '\0'; wordIndex++){
+        if(word[wordIndex] < 'a' || word[wordIndex] > 'z') return false;
         int letterIndex = word[wordIndex] - 'a';
         if(!curNode->children[letterIndex]) return false;
         curNode = curNode->children[letterIndex];


### PR DESCRIPTION
## Summary
- Characters outside `a-z` produce a negative or out-of-range index into `children[26]`, causing undefined behavior
- Added a guard at the start of each character loop in `insert`, `search`, and `delete` to return `false` immediately on any invalid character

Closes #4
Closes #10

## Test plan
- [ ] Compile: `gcc -Wall -Wextra -Werror src/trie.c src/main.c -o main`
- [ ] Manually verify: `insert(root, "Apple")` → returns `false`, no crash
- [ ] Manually verify: `insert(root, "b4ll")` → returns `false`, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)