### PR TITLE
fix: pass CODECOV_TOKEN to codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Fuzz (60s)
         if: runner.os == 'Linux'


### PR DESCRIPTION
Tokenless uploads are no longer supported by Codecov. Passes `CODECOV_TOKEN` secret to the upload step so the badge resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)